### PR TITLE
feat(transaction): add operation type ont ransaction summary

### DIFF
--- a/src/library/api/transactions/types.ts
+++ b/src/library/api/transactions/types.ts
@@ -1,4 +1,4 @@
-import { TransactionRequest } from 'fuels';
+import { Operation, TransactionRequest } from 'fuels';
 import { IAssetTransaction, ITransferAsset } from '../../assets';
 
 export enum SortOption {
@@ -78,6 +78,7 @@ export interface ITransactionSummary {
   origin: string;
   name: string;
   image?: string;
+  operations?: Operation[];
 }
 
 export interface ITransaction extends ICreateTransactionPayload {

--- a/src/library/assets/types.ts
+++ b/src/library/assets/types.ts
@@ -10,6 +10,7 @@ export type ITransferAsset = {
   assetId: string;
   amount: string;
   to: string;
+  recipientNickname: string;
 };
 
 export interface IAssetTransaction extends ITransferAsset {


### PR DESCRIPTION
- Add `operation` type inside the transaction summary. This type is used to create a custom view for transactions originated by connector;
- Add `recipientNickname` type into ITransferAsset